### PR TITLE
chore: Error Handling Refactor and Clipboard Handling Improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -55,4 +55,4 @@
   "remoteEnv": {
     "DISPLAY": "${localEnv:DISPLAY}"
   }
-} 
+}

--- a/justfile
+++ b/justfile
@@ -17,9 +17,14 @@ _default:
 # or install via `cargo install cargo-binstall`
 # Initialize the project by installing all the necessary tools.
 init:
+  cargo install cargo-binstall
   # Rust related init
   cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear dprint -y
-  
+
+  # toolchain
+  rustup component add clippy
+  rustup component add rustfmt
+
   # npm install -g pnpm typescript @napi-rs/cli @antfu/ni
   # Node.js related init
   yarn install
@@ -171,7 +176,7 @@ doc:
 [linux]
 install-linux-deps:
   @echo "📦 Linux依存関係をインストール中..."
-  sudo apt-get update
+  sudo apt-get update -y
   sudo apt-get install -y \
     libx11-dev \
     libxext-dev \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,18 +211,15 @@ pub fn read_clipboard_file_paths() -> napi::Result<ClipboardContent> {
       if result.text.is_none() && internal_result.text.is_err() {
         // テキストもファイルパスも取得できなかった場合、raw読み取りを試みる
         #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-        match current_platform::read_clipboard_raw() {
-          Ok(raw_data) => {
-            if !raw_data.is_empty() {
-              // UTF-8として解釈を試みる
-              if let Ok(text) = String::from_utf8(raw_data.clone()) {
-                if !text.trim().is_empty() {
-                  result.text = Some(text);
-                }
+        if let Ok(raw_data) = current_platform::read_clipboard_raw() {
+          if !raw_data.is_empty() {
+            // UTF-8として解釈を試みる
+            if let Ok(text) = String::from_utf8(raw_data.clone()) {
+              if !text.trim().is_empty() {
+                result.text = Some(text);
               }
             }
           }
-          Err(_) => {} // raw読み取りに失敗した場合は無視
         }
       }
     }

--- a/src/platforms/linux.rs
+++ b/src/platforms/linux.rs
@@ -67,17 +67,14 @@ pub fn write_clipboard_file_paths(paths: &[String]) -> Result<(), Error> {
       }
       Ok(())
     }
-    Ok(exit_status) => Err(Error::new(
-      ErrorKind::Other,
-      format!(
-        "xclip command failed with exit code: {:?}",
-        exit_status.code()
-      ),
-    )),
-    Err(e) => Err(Error::new(
-      ErrorKind::Other,
-      format!("Failed to execute xclip command: {}", e),
-    )),
+    Ok(exit_status) => Err(Error::other(format!(
+      "xclip command failed with exit code: {:?}",
+      exit_status.code()
+    ))),
+    Err(e) => Err(Error::other(format!(
+      "Failed to execute xclip command: {}",
+      e
+    ))),
   }
 }
 
@@ -93,16 +90,13 @@ pub fn read_clipboard_text() -> Result<String, Error> {
   if output.status.success() {
     let text = String::from_utf8_lossy(&output.stdout).into_owned();
     if text.is_empty() {
-      Err(Error::new(ErrorKind::Other, "No text content in clipboard"))
+      Err(Error::other("No text content in clipboard"))
     } else {
       Ok(text)
     }
   } else {
     let error = String::from_utf8_lossy(&output.stderr).into_owned();
-    Err(Error::new(
-      ErrorKind::Other,
-      format!("Failed to read clipboard: {}", error),
-    ))
+    Err(Error::other(format!("Failed to read clipboard: {}", error)))
   }
 }
 
@@ -117,16 +111,16 @@ pub fn read_clipboard_raw() -> Result<Vec<u8>, Error> {
 
   if output.status.success() {
     if output.stdout.is_empty() {
-      Err(Error::new(ErrorKind::Other, "No data in clipboard"))
+      Err(Error::other("No data in clipboard"))
     } else {
       Ok(output.stdout)
     }
   } else {
     let error = String::from_utf8_lossy(&output.stderr).into_owned();
-    Err(Error::new(
-      ErrorKind::Other,
-      format!("Failed to read clipboard raw data: {}", error),
-    ))
+    Err(Error::other(format!(
+      "Failed to read clipboard raw data: {}",
+      error
+    )))
   }
 }
 
@@ -172,10 +166,10 @@ pub fn read_clipboard_file_paths() -> Result<Vec<String>, Error> {
     Ok(paths)
   } else {
     let error = String::from_utf8_lossy(&output.stderr).into_owned();
-    Err(Error::new(
-      ErrorKind::Other,
-      format!("Failed to read clipboard for file paths: {}", error),
-    ))
+    Err(Error::other(format!(
+      "Failed to read clipboard for file paths: {}",
+      error
+    )))
   }
 }
 


### PR DESCRIPTION
This pull request includes several changes aimed at improving error handling, simplifying code, and enhancing initialization processes. The most important changes focus on refactoring error creation in Rust code, improving clipboard handling, and updating initialization scripts for better dependency management.

### Error Handling Refactor:
* Replaced `Error::new` with `Error::other` in multiple functions across `src/platforms/linux.rs` to simplify error creation and improve readability. [[1]](diffhunk://#diff-8e5951ea982e5733fa99080178638eff7ced7cdd4a9e74317a5e849e99c8ef00L70-R77) [[2]](diffhunk://#diff-8e5951ea982e5733fa99080178638eff7ced7cdd4a9e74317a5e849e99c8ef00L96-R99) [[3]](diffhunk://#diff-8e5951ea982e5733fa99080178638eff7ced7cdd4a9e74317a5e849e99c8ef00L120-R123) [[4]](diffhunk://#diff-8e5951ea982e5733fa99080178638eff7ced7cdd4a9e74317a5e849e99c8ef00L175-R172)

### Clipboard Handling Improvements:
* Refactored `read_clipboard_file_paths` in `src/lib.rs` to use `if let` for cleaner handling of raw clipboard data, removing unnecessary `match` statements. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L214-R214) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L225-L226)

### Initialization Script Enhancements:
* Added `cargo install cargo-binstall` and additional Rust toolchain components (`clippy` and `rustfmt`) to the `init` task in `justfile` to ensure a more complete setup for Rust development.
* Updated the `install-linux-deps` task in `justfile` to include `-y` flag for `sudo apt-get update` for non-interactive execution.
